### PR TITLE
Fix deduplication API validation

### DIFF
--- a/test/utils/test_deduplication.py
+++ b/test/utils/test_deduplication.py
@@ -65,6 +65,12 @@ def test_deduplicate_internally_single_item():
     assert len(result.duplicate_to_target_map) == 0
 
 
+def test_deduplicate_internally_single_item_no_embedding():
+    """Ensure ValueError is raised when no embeddings are provided."""
+    with pytest.raises(ValueError):
+        deduplicate_internally(texts=["hello"])
+
+
 def test_deduplicate_internally_with_mock_embedding():
     texts = ["Hello world!", "Hello world!", "HELLO WORLD!", "Something else"]
     mock_embedding_instance = MockEmbedding()


### PR DESCRIPTION
## Summary
- validate embedding parameters before processing
- handle single item deduplication without embeddings
- cover missing embedding case in tests

## Testing
- `pytest test/utils/test_deduplication.py test/utils/test_filename.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcb34f4c4832a81fdc0ca16ed0959

## Summary by Sourcery

Validate embedding parameters before deduplication and unify single-text handling to ensure correct error reporting and embedding retrieval.

Bug Fixes:
- Raise ValueError when neither or both of 'embedding_instance' and 'embeddings' are supplied.
- Fix single-item deduplication to retrieve embeddings or accept provided ones without errors.

Enhancements:
- Consolidate embedding retrieval logic for the single-text deduplication path.

Tests:
- Add a test to ensure a ValueError is raised when no embeddings are provided for a single-item deduplication call.