### PR TITLE
Fix Task.set_state to handle string inputs

### DIFF
--- a/camel/tasks/task.py
+++ b/camel/tasks/task.py
@@ -137,12 +137,15 @@ class Task(BaseModel):
         """
         self.id = id
 
-    def set_state(self, state: TaskState):
+    def set_state(self, state: Union[TaskState, str]):
         r"""Recursively set the state of the task and its subtasks.
 
         Args:
-            state (TaskState): The giving state.
+            state (Union[TaskState, str]): The giving state. If a string is
+                provided it will be converted to :class:`TaskState`.
         """
+        if isinstance(state, str):
+            state = TaskState(state)
         self.state = state
         if state == TaskState.DONE:
             for subtask in self.subtasks:


### PR DESCRIPTION
## Summary
- allow `Task.set_state` to accept either a `TaskState` enum or its string name

## Testing
- `pytest -q test/tasks/test_task.py::test_task -k ''` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683fcb9e6f20832ab02bda35a284384f

## Summary by Sourcery

Enhancements:
- Allow Task.set_state to accept string inputs and convert them to TaskState